### PR TITLE
feat: allow multi anmespace deployments with namespaceOverride (#25)

### DIFF
--- a/charts/typesense-operator/templates/_helpers.tpl
+++ b/charts/typesense-operator/templates/_helpers.tpl
@@ -24,6 +24,13 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Allow the release namespace to be overridden for multi-namespace deployments in combined charts.
+*/}}
+{{- define "typesense-operator.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "typesense-operator.chart" -}}

--- a/charts/typesense-operator/templates/deployment.yaml
+++ b/charts/typesense-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-controller-manager
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
     control-plane: controller-manager
   {{- include "typesense-operator.labels" . | nindent 4 }}

--- a/charts/typesense-operator/templates/leader-election-rbac.yaml
+++ b/charts/typesense-operator/templates/leader-election-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-leader-election-role
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
 rules:
@@ -50,4 +51,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: '{{ include "typesense-operator.fullname" . }}-controller-manager'
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ include "typesense-operator.namespace" . | quote }}

--- a/charts/typesense-operator/templates/manager-rbac.yaml
+++ b/charts/typesense-operator/templates/manager-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-manager-role
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
 rules:
@@ -179,4 +180,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: '{{ include "typesense-operator.fullname" . }}-controller-manager'
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ include "typesense-operator.namespace" . | quote }}

--- a/charts/typesense-operator/templates/metrics-auth-rbac.yaml
+++ b/charts/typesense-operator/templates/metrics-auth-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-metrics-auth-role
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
 rules:
@@ -31,4 +32,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: '{{ include "typesense-operator.fullname" . }}-controller-manager'
-  namespace: '{{ .Release.Namespace }}'
+  namespace: {{ include "typesense-operator.namespace" . | quote }}

--- a/charts/typesense-operator/templates/metrics-reader-rbac.yaml
+++ b/charts/typesense-operator/templates/metrics-reader-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-metrics-reader
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/typesense-operator/templates/metrics-service.yaml
+++ b/charts/typesense-operator/templates/metrics-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-controller-manager-metrics-service
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
     control-plane: controller-manager
   {{- include "typesense-operator.labels" . | nindent 4 }}

--- a/charts/typesense-operator/templates/serviceaccount.yaml
+++ b/charts/typesense-operator/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-controller-manager
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
   annotations:

--- a/charts/typesense-operator/templates/typesensecluster-editor-rbac.yaml
+++ b/charts/typesense-operator/templates/typesensecluster-editor-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-typesensecluster-editor-role
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/typesense-operator/templates/typesensecluster-viewer-rbac.yaml
+++ b/charts/typesense-operator/templates/typesensecluster-viewer-rbac.yaml
@@ -2,6 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: {{ include "typesense-operator.fullname" . }}-typesensecluster-viewer-role
+  namespace: {{ include "typesense-operator.namespace" . | quote }}
   labels:
   {{- include "typesense-operator.labels" . | nindent 4 }}
 rules:

--- a/charts/typesense-operator/values.yaml
+++ b/charts/typesense-operator/values.yaml
@@ -1,3 +1,5 @@
+namespaceOverride: ""
+
 controllerManager:
   manager:
     args:

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -4,9 +4,10 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"sort"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sort"
 )
 
 const (


### PR DESCRIPTION
This adds the possibility to allow the release namespace to be overridden for multi-namespace deployments in combined charts.

Fixes #25 