### PR TITLE
feat(ingres): allow to set the tls secret name and make ClusterIssuer optional (#99)

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,12 +245,14 @@ introducing `TypesenseCluster`, a new Custom Resource Definition:
 | serverDirectives  | Nginx Proxy serverDirectives         | X        |         |
 | locationDirectives| Nginx Proxy locationDirectives       | X        |         |
 | host              | Ingress Host                         |          |         |
-| clusterIssuer     | cert-manager `ClusterIssuer`         |          |         |
+| clusterIssuer     | cert-manager `ClusterIssuer`         | X        |         |
+| tlsSecretName     | TLS secret name to use               | X        |         |
 | ingressClassName  | Ingress to be used                   |          |         |
 | annotations       | User-Defined annotations             | X        |         |
 
 > [!IMPORTANT]
-> This feature requires the existence of [cert-manager](https://cert-manager.io/) in the cluster, but **does not** actively enforce it with an error.
+> This feature makes use of the existence of [cert-manager](https://cert-manager.io/) in the cluster, but **does not** actively enforce it with an error.
+> If no clusterIssuer is specified a valid certificate must be stored in a secret and the secret name must be provided in the tlsSecretName config.
 > If you are targeting Open Telekom Cloud, you might be interested in provisioning additionally the designated DNS solver webhook
 > for Open Telekom Cloud. You can find it [here](https://github.com/akyriako/cert-manager-webhook-opentelekomcloud).
 

--- a/api/v1alpha1/typesensecluster_types.go
+++ b/api/v1alpha1/typesensecluster_types.go
@@ -126,11 +126,15 @@ type IngressSpec struct {
 	ServerDirectives   *string `json:"serverDirectives,omitempty"`
 	LocationDirectives *string `json:"locationDirectives,omitempty"`
 
-	ClusterIssuer string `json:"clusterIssuer"`
+	// +optional
+	ClusterIssuer *string `json:"clusterIssuer,omitempty"`
 
 	IngressClassName string `json:"ingressClassName"`
 
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// +optional
+	TLSSecretName *string `json:"tlsSecretName,omitempty"`
 }
 
 type DocSearchScraperSpec struct {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -64,12 +64,22 @@ func (in *IngressSpec) DeepCopyInto(out *IngressSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ClusterIssuer != nil {
+		in, out := &in.ClusterIssuer, &out.ClusterIssuer
+		*out = new(string)
+		**out = **in
+	}
 	if in.Annotations != nil {
 		in, out := &in.Annotations, &out.Annotations
 		*out = make(map[string]string, len(*in))
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.TLSSecretName != nil {
+		in, out := &in.TLSSecretName, &out.TLSSecretName
+		*out = new(string)
+		**out = **in
 	}
 }
 

--- a/charts/typesense-operator/templates/typesensecluster-crd.yaml
+++ b/charts/typesense-operator/templates/typesensecluster-crd.yaml
@@ -1034,6 +1034,7 @@ spec:
                       type: string
                     type: object
                   clusterIssuer:
+                    default: ""
                     type: string
                   host:
                     pattern: ^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$
@@ -1049,8 +1050,10 @@ spec:
                     type: string
                   serverDirectives:
                     type: string
+                  tlsSecretName:
+                    default: ""
+                    type: string
                 required:
-                - clusterIssuer
                 - host
                 - ingressClassName
                 type: object
@@ -1074,12 +1077,12 @@ spec:
                         description: |-
                           Claims lists the names of resources, defined in spec.resourceClaims,
                           that are used by this container.
-  
-  
+
+
                           This is an alpha field and requires enabling the
                           DynamicResourceAllocation feature gate.
-  
-  
+
+
                           This field is immutable. It can only be set for containers.
                         items:
                           description: ResourceClaim references one entry in PodSpec.ResourceClaims.
@@ -1156,12 +1159,12 @@ spec:
                     description: |-
                       Claims lists the names of resources, defined in spec.resourceClaims,
                       that are used by this container.
-  
-  
+
+
                       This is an alpha field and requires enabling the
                       DynamicResourceAllocation feature gate.
-  
-  
+
+
                       This field is immutable. It can only be set for containers.
                     items:
                       description: ResourceClaim references one entry in PodSpec.ResourceClaims.
@@ -1339,8 +1342,8 @@ spec:
                         MatchLabelKeys cannot be set when LabelSelector isn't set.
                         Keys that don't exist in the incoming pod labels will
                         be ignored. A null or empty list means only match against labelSelector.
-  
-  
+
+
                         This is a beta field and requires the MatchLabelKeysInPodTopologySpread feature gate to be enabled (enabled by default).
                       items:
                         type: string
@@ -1379,8 +1382,8 @@ spec:
                         If value is nil, the constraint behaves as if MinDomains is equal to 1.
                         Valid values are integers greater than 0.
                         When value is not nil, WhenUnsatisfiable must be DoNotSchedule.
-  
-  
+
+
                         For example, in a 3-zone cluster, MaxSkew is set to 2, MinDomains is set to 5 and pods with the same
                         labelSelector spread as 2/2/2:
                         | zone1 | zone2 | zone3 |
@@ -1397,8 +1400,8 @@ spec:
                         when calculating pod topology spread skew. Options are:
                         - Honor: only nodes matching nodeAffinity/nodeSelector are included in the calculations.
                         - Ignore: nodeAffinity/nodeSelector are ignored. All nodes are included in the calculations.
-  
-  
+
+
                         If this value is nil, the behavior is equivalent to the Honor policy.
                         This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string
@@ -1409,8 +1412,8 @@ spec:
                         - Honor: nodes without taints, along with tainted nodes for which the incoming pod
                         has a toleration, are included.
                         - Ignore: node taints are ignored. All nodes are included.
-  
-  
+
+
                         If this value is nil, the behavior is equivalent to the Ignore policy.
                         This is a beta-level feature default enabled by the NodeInclusionPolicyInPodTopologySpread feature flag.
                       type: string

--- a/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
+++ b/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
@@ -1049,8 +1049,9 @@ spec:
                     type: string
                   serverDirectives:
                     type: string
+                  tlsSecretName:
+                    type: string
                 required:
-                - clusterIssuer
                 - host
                 - ingressClassName
                 type: object


### PR DESCRIPTION
Allow to define custom TLS Secret name.
Allow to not set a cluster manager if a preexisting cert secret is available

Fixes: #99 