### PR TITLE
feat(chart): allow to set imagePullSecrets for cotroller manager (#101)

### DIFF
--- a/charts/typesense-operator/templates/deployment.yaml
+++ b/charts/typesense-operator/templates/deployment.yaml
@@ -19,6 +19,10 @@ spec:
       annotations:
         kubectl.kubernetes.io/default-container: manager
     spec:
+      {{- with .Values.controllerManager.manager.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
         command:

--- a/charts/typesense-operator/values.yaml
+++ b/charts/typesense-operator/values.yaml
@@ -14,6 +14,7 @@ controllerManager:
       repository: akyriako78/typesense-operator
       tag: 0.2.20
     imagePullPolicy: IfNotPresent
+    imagePullSecrets: []
     resources:
       limits:
         cpu: 500m


### PR DESCRIPTION
Initially allow to set image pull secrets for the controller manager.

What is not done in here is that there is no possibility currently to set this for the reverse proxies.

Fixes (#101)