### PR TITLE
Improvement: avoid downgrades by syncing configmaps faster and waiting when they change

### DIFF
--- a/config/samples/ts_v1alpha1_typesensecluster_kind.yaml
+++ b/config/samples/ts_v1alpha1_typesensecluster_kind.yaml
@@ -35,8 +35,15 @@ metadata:
   name: c-kind-1
 spec:
   image: typesense/typesense:30.0.rc7-amd64
-  replicas: 5
+  replicas: 3
   corsDomains: "http://localhost,https://www.example.de"
+  resources:
+    limits:
+      cpu: "1200m"
+      memory: "1024Mi"
+    requests:
+      cpu: "100m"
+      memory: "64Mi"
   storage:
     size: 150Mi
     storageClassName: typesense-local-path
@@ -47,107 +54,107 @@ spec:
   additionalServerConfiguration:
     name: c-kind-1-server-configuration
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: c-kind-2-config
-data:
-  TYPESENSE_ENABLE_SEARCH_ANALYTICS: "true"
----
-apiVersion: v1
-kind: Secret
-metadata:
-  labels:
-    app.kubernetes.io/name: typesense-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: scraper-auth-docusaurus-example-com
-type: Opaque
-data:
-  KC_URL: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
-  KC_REALM: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
-  KC_CLIENT_ID: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
-  KC_CLIENT_SECRET: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
----
-apiVersion: ts.opentelekomcloud.com/v1alpha1
-kind: TypesenseCluster
-metadata:
-  labels:
-    app.kubernetes.io/name: typesense-operator
-    app.kubernetes.io/managed-by: kustomize
-  name: c-kind-2
-spec:
-  image: typesense/typesense:29.0
-  replicas: 7
-  adminApiKey:
-    name: typesense-common-bootstrap-key
-  enableCors: true
-  apiPort: 8108
-  healthProbeTimeoutInMilliseconds: 1500
-  resources:
-    limits:
-      cpu: "200m"
-      memory: "1024Mi"
-    requests:
-      cpu: "100m"
-      memory: "64Mi"
-  storage:
-    size: 75Mi
-    storageClassName: typesense-local-path
-  metrics:
-    release: promstack
-  ingress:
-    referer: referer.example.com
-    host: host.example.com
-    path: /
-    pathType: ImplementationSpecific
-    ingressClassName: nginx
-    clusterIssuer: lets-encrypt-prod
-#    readOnlyRootFilesystem:
-#      volumes:
-#        - name: nginx-var-cache
-#          emptyDir: {}
-#        - name: run
-#          emptyDir: {}
-#      volumeMounts:
-#        - name: nginx-var-cache
-#          mountPath: /var/cache/nginx
-#        - name: run
-#          mountPath: /run
----
+#apiVersion: v1
+#kind: ConfigMap
+#metadata:
+#  name: c-kind-2-config
+#data:
+#  TYPESENSE_ENABLE_SEARCH_ANALYTICS: "true"
+#---
+#apiVersion: v1
+#kind: Secret
+#metadata:
+#  labels:
+#    app.kubernetes.io/name: typesense-operator
+#    app.kubernetes.io/managed-by: kustomize
+#  name: scraper-auth-docusaurus-example-com
+#type: Opaque
+#data:
+#  KC_URL: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
+#  KC_REALM: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
+#  KC_CLIENT_ID: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
+#  KC_CLIENT_SECRET: VGhpc0lzTm90QVNlY3VyZVBhc3N3b3Jk
+#---
 #apiVersion: ts.opentelekomcloud.com/v1alpha1
 #kind: TypesenseCluster
 #metadata:
 #  labels:
 #    app.kubernetes.io/name: typesense-operator
 #    app.kubernetes.io/managed-by: kustomize
-#  name: c-kind-3
+#  name: c-kind-2
 #spec:
-#  image: typesense/typesense:27.1
-#  replicas: 1
-#  apiPort: 18108
-#  peeringPort: 18107
-#  enableCors: true
-#  corsDomains: "http://localhost,https://www.example.de"
-#  storage:
-#    size: 10Mi
-#    storageClassName: typesense-local-path
+#  image: typesense/typesense:29.0
+#  replicas: 7
 #  adminApiKey:
 #    name: typesense-common-bootstrap-key
+#  enableCors: true
+#  apiPort: 8108
+#  healthProbeTimeoutInMilliseconds: 1500
+#  resources:
+#    limits:
+#      cpu: "200m"
+#      memory: "1024Mi"
+#    requests:
+#      cpu: "100m"
+#      memory: "64Mi"
+#  storage:
+#    size: 75Mi
+#    storageClassName: typesense-local-path
+#  metrics:
+#    release: promstack
 #  ingress:
-#    host: www.example.de
+#    referer: referer.example.com
+#    host: host.example.com
+#    path: /
+#    pathType: ImplementationSpecific
 #    ingressClassName: nginx
-#    clusterIssuer: opentelekomcloud-letsencrypt-staging
-#    resources:
-#      limits:
-#        cpu: "300m"
-#        memory: "128Mi"
-#      requests:
-#        cpu: "100m"
-#        memory: "32Mi"
-#  scrapers:
-#    - name: docusaurus-example-com
-#      image: typesense/docsearch-scraper:0.11.0
-#      authConfiguration:
-#        name: scraper-auth-docusaurus-example-com
-#      config: "{\"index_name\":\"docuraurus-example\",\"start_urls\":[\"https://docusaurus.example.com/\"],\"sitemap_urls\":[\"https://docusaurus.example.com/sitemap.xml\"],\"sitemap_alternate_links\":true,\"stop_urls\":[\"/tests\"],\"selectors\":{\"lvl0\":{\"selector\":\"(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]\",\"type\":\"xpath\",\"global\":true,\"default_value\":\"Documentation\"},\"lvl1\":\"header h1\",\"lvl2\":\"article h2\",\"lvl3\":\"article h3\",\"lvl4\":\"article h4\",\"lvl5\":\"article h5, article td:first-child\",\"lvl6\":\"article h6\",\"text\":\"article p, article li, article td:last-child\"},\"strip_chars\":\" .,;:#\",\"custom_settings\":{\"separatorsToIndex\":\"_\",\"attributesForFaceting\":[\"language\",\"version\",\"type\",\"docusaurus_tag\"],\"attributesToRetrieve\":[\"hierarchy\",\"content\",\"anchor\",\"url\",\"url_without_anchor\",\"type\"]},\"conversation_id\":[\"833762294\"],\"nb_hits\":46250}"
-#      schedule: '*/2 * * * *'
+#    clusterIssuer: lets-encrypt-prod
+##    readOnlyRootFilesystem:
+##      volumes:
+##        - name: nginx-var-cache
+##          emptyDir: {}
+##        - name: run
+##          emptyDir: {}
+##      volumeMounts:
+##        - name: nginx-var-cache
+##          mountPath: /var/cache/nginx
+##        - name: run
+##          mountPath: /run
+#---
+##apiVersion: ts.opentelekomcloud.com/v1alpha1
+##kind: TypesenseCluster
+##metadata:
+##  labels:
+##    app.kubernetes.io/name: typesense-operator
+##    app.kubernetes.io/managed-by: kustomize
+##  name: c-kind-3
+##spec:
+##  image: typesense/typesense:27.1
+##  replicas: 1
+##  apiPort: 18108
+##  peeringPort: 18107
+##  enableCors: true
+##  corsDomains: "http://localhost,https://www.example.de"
+##  storage:
+##    size: 10Mi
+##    storageClassName: typesense-local-path
+##  adminApiKey:
+##    name: typesense-common-bootstrap-key
+##  ingress:
+##    host: www.example.de
+##    ingressClassName: nginx
+##    clusterIssuer: opentelekomcloud-letsencrypt-staging
+##    resources:
+##      limits:
+##        cpu: "300m"
+##        memory: "128Mi"
+##      requests:
+##        cpu: "100m"
+##        memory: "32Mi"
+##  scrapers:
+##    - name: docusaurus-example-com
+##      image: typesense/docsearch-scraper:0.11.0
+##      authConfiguration:
+##        name: scraper-auth-docusaurus-example-com
+##      config: "{\"index_name\":\"docuraurus-example\",\"start_urls\":[\"https://docusaurus.example.com/\"],\"sitemap_urls\":[\"https://docusaurus.example.com/sitemap.xml\"],\"sitemap_alternate_links\":true,\"stop_urls\":[\"/tests\"],\"selectors\":{\"lvl0\":{\"selector\":\"(//ul[contains(@class,'menu__list')]//a[contains(@class, 'menu__link menu__link--sublist menu__link--active')]/text() | //nav[contains(@class, 'navbar')]//a[contains(@class, 'navbar__link--active')]/text())[last()]\",\"type\":\"xpath\",\"global\":true,\"default_value\":\"Documentation\"},\"lvl1\":\"header h1\",\"lvl2\":\"article h2\",\"lvl3\":\"article h3\",\"lvl4\":\"article h4\",\"lvl5\":\"article h5, article td:first-child\",\"lvl6\":\"article h6\",\"text\":\"article p, article li, article td:last-child\"},\"strip_chars\":\" .,;:#\",\"custom_settings\":{\"separatorsToIndex\":\"_\",\"attributesForFaceting\":[\"language\",\"version\",\"type\",\"docusaurus_tag\"],\"attributesToRetrieve\":[\"hierarchy\",\"content\",\"anchor\",\"url\",\"url_without_anchor\",\"type\"]},\"conversation_id\":[\"833762294\"],\"nb_hits\":46250}"
+##      schedule: '*/2 * * * *'

--- a/internal/controller/typesensecluster_condition_types.go
+++ b/internal/controller/typesensecluster_condition_types.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,7 +37,7 @@ const (
 )
 
 func (r *TypesenseClusterReconciler) initConditions(ctx context.Context, ts *tsv1alpha1.TypesenseCluster) error {
-	if ts.Status.Conditions == nil || len(ts.Status.Conditions) == 0 {
+	if len(ts.Status.Conditions) == 0 {
 		if err := r.patchStatus(ctx, ts, func(status *tsv1alpha1.TypesenseClusterStatus) {
 			meta.SetStatusCondition(&ts.Status.Conditions, metav1.Condition{Type: ConditionTypeReady, Status: metav1.ConditionUnknown, Reason: ConditionReasonReconciliationInProgress, Message: InitReconciliationMessage})
 			status.Phase = "Bootstrapping"

--- a/internal/controller/typesensecluster_configmap.go
+++ b/internal/controller/typesensecluster_configmap.go
@@ -109,6 +109,9 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 	}
 
 	nodes, err := r.getNodes(ctx, ts, *replicas, false)
+	if err != nil {
+		return nil, 0, false, err
+	}
 	fallback, err := r.getNodes(ctx, ts, *replicas, true)
 	if err != nil {
 		return nil, 0, false, err

--- a/internal/controller/typesensecluster_configmap.go
+++ b/internal/controller/typesensecluster_configmap.go
@@ -3,53 +3,55 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	discoveryv1 "k8s.io/api/discovery/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strings"
 )
 
-func (r *TypesenseClusterReconciler) ReconcileConfigMap(ctx context.Context, ts tsv1alpha1.TypesenseCluster) (updated *bool, err error) {
+func (r *TypesenseClusterReconciler) ReconcileConfigMap(ctx context.Context, ts tsv1alpha1.TypesenseCluster) (bool, error) {
 	r.logger.V(debugLevel).Info("reconciling config map")
 
 	configMapName := fmt.Sprintf(ClusterNodesConfigMap, ts.Name)
-	configMapExists := true
 	configMapObjectKey := client.ObjectKey{Namespace: ts.Namespace, Name: configMapName}
 
+	configMapExists := true
 	var cm = &v1.ConfigMap{}
-	if err = r.Get(ctx, configMapObjectKey, cm); err != nil {
+	if err := r.Get(ctx, configMapObjectKey, cm); err != nil {
 		if apierrors.IsNotFound(err) {
 			configMapExists = false
 		} else {
 			r.logger.Error(err, fmt.Sprintf("unable to fetch config map: %s", configMapName))
-			return ptr.To[bool](false), err
+			return false, err
 		}
 	}
 
+	var err error
+	updated := false
 	if !configMapExists {
 		r.logger.V(debugLevel).Info("creating config map", "configmap", configMapObjectKey.Name)
 
-		cm, err = r.createConfigMap(ctx, configMapObjectKey, &ts)
+		_, err := r.createConfigMap(ctx, configMapObjectKey, &ts)
 		if err != nil {
 			r.logger.Error(err, "creating config map failed", "configmap", configMapObjectKey.Name)
-			return nil, err
+			return false, err
 		}
 	} else {
 		r.logger.V(debugLevel).Info("updating config map", "configmap", configMapObjectKey.Name)
 
-		cm, _, err = r.updateConfigMap(ctx, &ts, cm, nil)
+		_, _, updated, err = r.updateConfigMap(ctx, &ts, cm, nil)
 		if err != nil {
-			return nil, err
+			return false, err
 		}
 	}
 
-	return &configMapExists, nil
+	return updated, nil
 }
 
 const nodeNameLenLimit = 64
@@ -81,7 +83,7 @@ func (r *TypesenseClusterReconciler) createConfigMap(ctx context.Context, key cl
 	return cm, nil
 }
 
-func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *tsv1alpha1.TypesenseCluster, cm *v1.ConfigMap, replicas *int32) (*v1.ConfigMap, int, error) {
+func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *tsv1alpha1.TypesenseCluster, cm *v1.ConfigMap, replicas *int32) (*v1.ConfigMap, int, bool, error) {
 	stsName := fmt.Sprintf(ClusterStatefulSet, ts.Name)
 	stsObjectKey := client.ObjectKey{
 		Name:      stsName,
@@ -93,13 +95,13 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 		if apierrors.IsNotFound(err) {
 			err := r.deleteConfigMap(ctx, cm)
 			if err != nil {
-				return nil, 0, err
+				return nil, 0, false, err
 			}
 		} else {
 			r.logger.Error(err, fmt.Sprintf("unable to fetch statefulset: %s", stsName))
 		}
 
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	if replicas == nil {
@@ -109,13 +111,13 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 	nodes, err := r.getNodes(ctx, ts, *replicas, false)
 	fallback, err := r.getNodes(ctx, ts, *replicas, true)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, false, err
 	}
 
 	availableNodes := len(nodes)
 	if availableNodes == 0 {
 		r.logger.V(debugLevel).Info("empty quorum configuration")
-		return nil, 0, fmt.Errorf("empty quorum configuration")
+		return nil, 0, false, fmt.Errorf("empty quorum configuration")
 	}
 
 	desired := cm.DeepCopy()
@@ -126,17 +128,19 @@ func (r *TypesenseClusterReconciler) updateConfigMap(ctx context.Context, ts *ts
 
 	r.logger.V(debugLevel).Info("current quorum configuration", "size", availableNodes, "nodes", nodes)
 
+	updated := false
 	if cm.Data["nodes"] != desired.Data["nodes"] || cm.Data["fallback"] != desired.Data["fallback"] {
 		r.logger.Info("updating quorum configuration", "size", availableNodes, "nodes", nodes)
 
 		err := r.Update(ctx, desired)
 		if err != nil {
 			r.logger.Error(err, "updating quorum configuration failed")
-			return nil, 0, err
+			return nil, 0, false, err
 		}
+		updated = true
 	}
 
-	return desired, availableNodes, nil
+	return desired, availableNodes, updated, nil
 }
 
 func (r *TypesenseClusterReconciler) deleteConfigMap(ctx context.Context, cm *v1.ConfigMap) error {

--- a/internal/controller/typesensecluster_controller.go
+++ b/internal/controller/typesensecluster_controller.go
@@ -135,6 +135,11 @@ func (r *TypesenseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 	if updated {
 		r.logger.Info("config map updated", "configmap", ts.Name)
+		err = r.ForcePodsConfigMapUpdate(ctx, &ts)
+		if err != nil {
+			r.logger.Error(err, "failed to force pods configmap update", "configmap", ts.Name)
+		}
+		// TODO: remove this if forced configmap update is working
 		r.logger.Info("requeueing to give cluster time to update", "configmap", ts.Name, "requeueAfter", configMapRequeuePeriod)
 		return ctrl.Result{RequeueAfter: configMapRequeuePeriod}, nil
 	}

--- a/internal/controller/typesensecluster_controller.go
+++ b/internal/controller/typesensecluster_controller.go
@@ -195,7 +195,7 @@ func (r *TypesenseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	cond := ConditionReasonQuorumStateUnknown
-	if updated {
+	if !updated {
 		condition, _, err := r.ReconcileQuorum(ctx, &ts, secret, client.ObjectKeyFromObject(sts))
 		if err != nil {
 			r.logger.Error(err, "reconciling quorum health failed")
@@ -247,7 +247,7 @@ func (r *TypesenseClusterReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	}
 
 	lastAction := "bootstrapping"
-	if updated {
+	if !updated {
 		lastAction = "reconciling"
 	}
 	requeueAfter = time.Duration(60+terminationGracePeriodSeconds) * time.Second

--- a/internal/controller/typesensecluster_helpers.go
+++ b/internal/controller/typesensecluster_helpers.go
@@ -2,17 +2,9 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/forced-configmap-update-time"
 )
 
 func (r *TypesenseClusterReconciler) patchStatus(
@@ -29,35 +21,5 @@ func (r *TypesenseClusterReconciler) patchStatus(
 		return err
 	}
 
-	return nil
-}
-
-// ForcePodsConfigMapUpdate forces a configmap update for all pods in the statefulset
-// it should be called after a configmap update occurs
-// https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically
-func (r *TypesenseClusterReconciler) ForcePodsConfigMapUpdate(ctx context.Context, ts *tsv1alpha1.TypesenseCluster) error {
-	labelMap := make(map[string]string)
-	labelMap["app"] = fmt.Sprintf(ClusterAppLabel, ts.Name)
-	labelSelector := labels.SelectorFromSet(labelMap)
-
-	var podList v1.PodList
-	if err := r.Client.List(ctx, &podList,
-		client.InNamespace(ts.Namespace),
-		client.MatchingLabelsSelector{Selector: labelSelector},
-	); err != nil {
-		return err
-	}
-
-	var err error
-	for _, pod := range podList.Items {
-		pod.Annotations[ForceConfigMapUpdateAnnotation] = time.Now().Format(time.RFC3339)
-		err = r.Update(ctx, &pod)
-		if err != nil {
-			r.logger.Error(err, "failed to update pod metadata", "pod", pod.Name)
-		}
-	}
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/internal/controller/typesensecluster_helpers.go
+++ b/internal/controller/typesensecluster_helpers.go
@@ -2,8 +2,17 @@ package controller
 
 import (
 	"context"
+	"fmt"
+	"time"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/v1alpha1/forced-configmap-update-time"
 )
 
 func (r *TypesenseClusterReconciler) patchStatus(
@@ -20,5 +29,35 @@ func (r *TypesenseClusterReconciler) patchStatus(
 		return err
 	}
 
+	return nil
+}
+
+// ForcePodsConfigMapUpdate forces a configmap update for all pods in the statefulset
+// it should be called after a configmap update occurs
+// https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#mounted-configmaps-are-updated-automatically
+func (r *TypesenseClusterReconciler) ForcePodsConfigMapUpdate(ctx context.Context, ts *tsv1alpha1.TypesenseCluster) error {
+	labelMap := make(map[string]string)
+	labelMap["app"] = fmt.Sprintf(ClusterAppLabel, ts.Name)
+	labelSelector := labels.SelectorFromSet(labelMap)
+
+	var podList v1.PodList
+	if err := r.Client.List(ctx, &podList,
+		client.InNamespace(ts.Namespace),
+		client.MatchingLabelsSelector{Selector: labelSelector},
+	); err != nil {
+		return err
+	}
+
+	var err error
+	for _, pod := range podList.Items {
+		pod.Annotations[ForceConfigMapUpdateAnnotation] = time.Now().Format(time.RFC3339)
+		err = r.Update(ctx, &pod)
+		if err != nil {
+			r.logger.Error(err, "failed to update pod metadata", "pod", pod.Name)
+		}
+	}
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/internal/controller/typesensecluster_helpers.go
+++ b/internal/controller/typesensecluster_helpers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/v1alpha1/forced-configmap-update-time"
+	ForceConfigMapUpdateAnnotation = "ts.opentelekomcloud.com/forced-configmap-update-time"
 )
 
 func (r *TypesenseClusterReconciler) patchStatus(

--- a/internal/controller/typesensecluster_quorum.go
+++ b/internal/controller/typesensecluster_quorum.go
@@ -216,7 +216,7 @@ func (r *TypesenseClusterReconciler) downgradeQuorum(
 		return ConditionReasonQuorumNotReady, 0, err
 	}
 
-	_, size, err := r.updateConfigMap(ctx, ts, cm, ptr.To[int32](desiredReplicas))
+	_, size, _, err := r.updateConfigMap(ctx, ts, cm, ptr.To[int32](desiredReplicas))
 	if err != nil {
 		return ConditionReasonQuorumNotReady, 0, err
 	}
@@ -246,7 +246,7 @@ func (r *TypesenseClusterReconciler) upgradeQuorum(
 		return ConditionReasonQuorumNotReady, 0, err
 	}
 
-	_, _, err = r.updateConfigMap(ctx, ts, cm, &size)
+	_, _, _, err = r.updateConfigMap(ctx, ts, cm, &size)
 	if err != nil {
 		return ConditionReasonQuorumNotReady, 0, err
 	}

--- a/internal/controller/typesensecluster_quorum.go
+++ b/internal/controller/typesensecluster_quorum.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
@@ -89,6 +90,10 @@ func (r *TypesenseClusterReconciler) ReconcileQuorum(ctx context.Context, ts *ts
 	r.logger.V(debugLevel).Info("reporting cluster status", "status", clusterStatus)
 
 	if clusterStatus == ClusterStatusSplitBrain {
+		nodeslist := strings.Split(quorum.NodesListConfigMap.Data["nodeslist"], ",")
+		if _, c := contains(nodeslist, fmt.Sprintf(ClusterStatefulSet, ts.Name)); c == true {
+			return ConditionReasonQuorumNotReadyWaitATerm, 0, nil
+		}
 		return r.downgradeQuorum(ctx, ts, quorum.NodesListConfigMap, stsObjectKey, sts.Status.ReadyReplicas, int32(quorum.MinRequiredNodes))
 	}
 
@@ -142,6 +147,10 @@ func (r *TypesenseClusterReconciler) ReconcileQuorum(ctx context.Context, ts *ts
 	}
 
 	if clusterStatus == ClusterStatusElectionDeadlock {
+		nodeslist := strings.Split(quorum.NodesListConfigMap.Data["nodeslist"], ",")
+		if _, c := contains(nodeslist, fmt.Sprintf(ClusterStatefulSet, ts.Name)); c == true {
+			return ConditionReasonQuorumNotReadyWaitATerm, 0, nil
+		}
 		return r.downgradeQuorum(ctx, ts, quorum.NodesListConfigMap, stsObjectKey, int32(healthyNodes), int32(minRequiredNodes))
 	}
 
@@ -216,7 +225,7 @@ func (r *TypesenseClusterReconciler) downgradeQuorum(
 		return ConditionReasonQuorumNotReady, 0, err
 	}
 
-	_, size, _, err := r.updateConfigMap(ctx, ts, cm, ptr.To[int32](desiredReplicas))
+	_, size, _, err := r.updateConfigMap(ctx, ts, cm, ptr.To[int32](desiredReplicas), true)
 	if err != nil {
 		return ConditionReasonQuorumNotReady, 0, err
 	}
@@ -246,7 +255,7 @@ func (r *TypesenseClusterReconciler) upgradeQuorum(
 		return ConditionReasonQuorumNotReady, 0, err
 	}
 
-	_, _, _, err = r.updateConfigMap(ctx, ts, cm, &size)
+	_, _, _, err = r.updateConfigMap(ctx, ts, cm, &size, true)
 	if err != nil {
 		return ConditionReasonQuorumNotReady, 0, err
 	}

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -99,7 +99,7 @@ func (r *TypesenseClusterReconciler) ReconcileStatefulSet(ctx context.Context, t
 					r.logger.V(debugLevel).Error(err, fmt.Sprintf("unable to fetch config map: %s", configMapName))
 				}
 
-				_, _, err = r.updateConfigMap(ctx, ts, cm, updatedSts.Spec.Replicas)
+				_, _, _, err = r.updateConfigMap(ctx, ts, cm, updatedSts.Spec.Replicas)
 				if err != nil {
 					r.logger.V(debugLevel).Error(err, fmt.Sprintf("unable to update config map: %s", configMapName))
 				}

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -5,6 +5,10 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
 	tsv1alpha1 "github.com/akyriako/typesense-operator/api/v1alpha1"
 	"github.com/mitchellh/hashstructure/v2"
 	appsv1 "k8s.io/api/apps/v1"
@@ -15,9 +19,6 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (
@@ -99,7 +100,7 @@ func (r *TypesenseClusterReconciler) ReconcileStatefulSet(ctx context.Context, t
 					r.logger.V(debugLevel).Error(err, fmt.Sprintf("unable to fetch config map: %s", configMapName))
 				}
 
-				_, _, _, err = r.updateConfigMap(ctx, ts, cm, updatedSts.Spec.Replicas)
+				_, _, _, err = r.updateConfigMap(ctx, ts, cm, updatedSts.Spec.Replicas, true)
 				if err != nil {
 					r.logger.V(debugLevel).Error(err, fmt.Sprintf("unable to update config map: %s", configMapName))
 				}


### PR DESCRIPTION
This PR reworks when quorom is reconciled.

The main reasoning behind the changes is to avoid detecting quorum status and taking action while the most current list of pod IPs is still propagating to the pods. If the configmap updated... we must wait.

I discovered even brand-new/empty clusters get downgraded during updates (I was using simple cpu/memory spec changes) even though their pods start back up and join the cluster rather quickly. Watching logs indicated both existing pods and brand new ones weren't getting updated config maps.

This set of changes has stabilized both brand-new/empty clusters and the clusters I'm running in my staging environment with >20min startup/ready times (due to large amounts of data to load).