### PR TITLE
When OpenShift is detected, do not set the runAsUser and fsGroup

### DIFF
--- a/charts/typesense-operator/templates/deployment.yaml
+++ b/charts/typesense-operator/templates/deployment.yaml
@@ -21,6 +21,11 @@ spec:
     spec:
       containers:
       - args: {{- toYaml .Values.controllerManager.manager.args | nindent 8 }}
+{{- if (eq .Values.controllerManager.manager.openshiftAdaptSecurityContext "force") }}
+        - --is-openshift=true
+{{- else if (eq .Values.controllerManager.manager.openshiftAdaptSecurityContext "disabled") }}
+        - --is-openshift=false
+{{- end }}
         command:
         - /manager
         env:

--- a/charts/typesense-operator/values.yaml
+++ b/charts/typesense-operator/values.yaml
@@ -5,6 +5,9 @@ controllerManager:
     - --leader-elect
     - --health-probe-bind-address=:8081
     - --zap-log-level=debug
+    # OpenShift is auto-detected at runtime. To explicitly enable/disable OpenShift mode set
+    # openshiftAdaptSecurityContext to "force" or "disabled"
+    openshiftAdaptSecurityContext: auto
     containerSecurityContext:
       allowPrivilegeEscalation: false
       capabilities:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -64,6 +64,8 @@ spec:
           - --leader-elect
           - --health-probe-bind-address=:8081
           - --zap-log-level=debug
+          # OpenShift is auto-detected at runtime. To explicitly enable/disable OpenShift mode, uncomment:
+          # - --is-openshift=true
         image: controller:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/internal/controller/typesensecluster_controller.go
+++ b/internal/controller/typesensecluster_controller.go
@@ -52,6 +52,7 @@ type TypesenseClusterReconciler struct {
 	ClientSet       *kubernetes.Clientset
 	Configuration   *rest.Config
 	InCluster       bool
+	IsOpenshift     bool
 }
 
 type TypesenseClusterReconciliationPhase struct {

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -220,11 +220,17 @@ func (r *TypesenseClusterReconciler) buildStatefulSet(ctx context.Context, key c
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: getObjectMeta(ts, &key.Name, podAnnotations),
 				Spec: corev1.PodSpec{
-					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser:    ptr.To[int64](10000),
-						FSGroup:      ptr.To[int64](2000),
-						RunAsGroup:   ptr.To[int64](3000),
-						RunAsNonRoot: ptr.To[bool](true)},
+					SecurityContext: func() *corev1.PodSecurityContext {
+						securityContext := &corev1.PodSecurityContext{
+							RunAsGroup:   ptr.To[int64](3000),
+							RunAsNonRoot: ptr.To[bool](true),
+						}
+						if !r.IsOpenshift {
+							securityContext.RunAsUser = ptr.To[int64](10000)
+							securityContext.FSGroup = ptr.To[int64](2000)
+						}
+						return securityContext
+					}(),
 					TerminationGracePeriodSeconds: ptr.To[int64](5),
 					ReadinessGates: []corev1.PodReadinessGate{
 						{


### PR DESCRIPTION
The operator currently cannot be used on Openshift/OKD because of the hard-coded runAsUser and fsGroup attributes in the securitycontext. 

The people behind Openshift/OKD consider hard-coded userid's a security hazard, because other pods that share the same volume and userid might access the data from the pod. 

So every namespace is assigned a random range of UID's that can be used. Best practice is to omit runAsUser so that an UID from this range is automatically selected. That is what this patch does, when Openshift is detected, runAsUser and fsGroup are omitted. 

With a switch this Openshift-compatibility mode can be forced to be off or on. The automatic detection is then not used.