### PR TITLE
Add storage.accessMode and storage.annotations to the CRD

### DIFF
--- a/charts/typesense-operator/templates/typesensecluster-crd.yaml
+++ b/charts/typesense-operator/templates/typesensecluster-crd.yaml
@@ -3459,6 +3459,16 @@ spec:
                     x-kubernetes-int-or-string: true
                   storageClassName:
                     type: string
+                  accessMode:
+                    default: ReadWriteOnce
+                    enum:
+                    - ReadWriteOnce
+                    - ReadWriteMany
+                    type: string
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    type: object
                 required:
                 - storageClassName
                 type: object


### PR DESCRIPTION
The new storage.accessMode and .annotations properties were not added to the CRD. As a result all (?) typesense-clusters failed due to the restriction that accessMode is required.