### PR TITLE
feat: add pod scheduling support for operator HA

### DIFF
--- a/charts/typesense-operator/Chart.yaml
+++ b/charts/typesense-operator/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.5
+version: 0.3.6
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/typesense-operator/README.md
+++ b/charts/typesense-operator/README.md
@@ -18,6 +18,29 @@ helm repo update
 helm upgrade --install typesense-operator tyko/typesense-operator -n typesense-system --create-namespace
 ```
 
+## 🏗️ High Availability
+
+Deploy with multiple replicas and pod anti-affinity:
+
+```yaml
+# values.yaml
+controllerManager:
+  replicas: 2
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: control-plane
+                operator: In
+                values: [controller-manager]
+          topologyKey: kubernetes.io/hostname
+```
+
+For more options, see [Kubernetes Pod Scheduling](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/).
+
+```
+
 <details>
 <summary>Quick example for Open Telekom Cloud CCE</summary>
 

--- a/charts/typesense-operator/templates/deployment.yaml
+++ b/charts/typesense-operator/templates/deployment.yaml
@@ -50,4 +50,13 @@ spec:
       securityContext: {{- toYaml .Values.controllerManager.podSecurityContext | nindent
         8 }}
       serviceAccountName: {{ include "typesense-operator.fullname" . }}-controller-manager
+      {{- with .Values.controllerManager.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.controllerManager.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
       terminationGracePeriodSeconds: 10

--- a/charts/typesense-operator/values.yaml
+++ b/charts/typesense-operator/values.yaml
@@ -24,6 +24,9 @@ controllerManager:
   podSecurityContext:
     runAsNonRoot: true
   replicas: 1
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
   serviceAccount:
     annotations: {}
 imagePullSecrets: []


### PR DESCRIPTION
## Summary
Fixes #209 - Adds pod scheduling configuration support for operator controller pods to enable high availability deployments.

## Problem
When deploying the operator with multiple replicas for HA, pods could be scheduled on the same node, undermining fault tolerance. Users had no way to configure pod anti-affinity or other scheduling constraints.

## Solution
Added support for `affinity`, `nodeSelector`, and `tolerations` in Helm values, following the same pattern used by the TypesenseCluster CRD.

## Changes
- **Helm Values** (`values.yaml`): Added `affinity`, `nodeSelector`, `tolerations` fields (opt-in, empty by default)
- **Deployment Template** (`deployment.yaml`): Wire values to pod spec using `{{- with }}` blocks
- **Chart Version** (`Chart.yaml`): Bumped to 0.3.6
- **Documentation** (`README.md`): Added HA configuration section with example

## Testing
✅ Helm chart lints successfully  
✅ Default configuration renders without affinity (backward compatible)  
✅ HA configuration with anti-affinity renders correctly  
✅ Deployed on Kind 2-node cluster - pods scheduled on different nodes  
✅ Pod rescheduling works correctly with anti-affinity constraints  
✅ Leader election works with multiple replicas  

## Example Usage
```yaml
# values.yaml
controllerManager:
  replicas: 2
  affinity:
    podAntiAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        - labelSelector:
            matchExpressions:
              - key: control-plane
                operator: In
                values: [controller-manager]
          topologyKey: kubernetes.io/hostname
```

## Backward Compatibility
✅ Fully backward compatible
- All new fields default to empty (`{}` or `[]`)
- Existing deployments unaffected
- Opt-in configuration approach

## Files Changed
- `charts/typesense-operator/values.yaml` (+3 lines)
- `charts/typesense-operator/templates/deployment.yaml` (+9 lines)
- `charts/typesense-operator/Chart.yaml` (version bump)
- `charts/typesense-operator/README.md` (+23 lines)

**Total**: 4 files changed, 36 insertions(+), 1 deletion(-)