### PR TITLE
add rudimentary support for service configurables

### DIFF
--- a/api/v1alpha1/typesensecluster_types.go
+++ b/api/v1alpha1/typesensecluster_types.go
@@ -121,6 +121,8 @@ type TypesenseClusterSpec struct {
 
 	Ingress *IngressSpec `json:"ingress,omitempty"`
 
+	Service *ServiceSpec `json:"service,omitempty"`
+
 	HttpRoutes []HttpRouteSpec `json:"httpRoutes,omitempty"`
 
 	Scrapers []DocSearchScraperSpec `json:"scrapers,omitempty"`

--- a/api/v1alpha1/typesensecluster_types_service.go
+++ b/api/v1alpha1/typesensecluster_types_service.go
@@ -6,19 +6,9 @@ import (
 
 type ServiceSpec struct {
 	// +optional
-	Labels map[string]string `json:"labels,omitempty"`
-
-	// +optional
-	Annotations map[string]string `json:"annotations,omitempty"`
-
-	// +optional
 	// +kubebuilder:default:="ClusterIP"
-	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer;ExternalName
+	// +kubebuilder:validation:Enum=ClusterIP;LoadBalancer
 	Type corev1.ServiceType `json:"type"`
-
-	// +optional
-	// +kubebuilder:validation:Enum=Cluster;Local
-	InternalTrafficPolicy *corev1.ServiceInternalTrafficPolicy `json:"internalTrafficPolicy,omitempty"`
 
 	// +optional
 	// +kubebuilder:default:="Cluster"

--- a/api/v1alpha1/typesensecluster_types_service.go
+++ b/api/v1alpha1/typesensecluster_types_service.go
@@ -1,0 +1,27 @@
+package v1alpha1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type ServiceSpec struct {
+	// +optional
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// +optional
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// +optional
+	// +kubebuilder:default:="ClusterIP"
+	// +kubebuilder:validation:Enum=ClusterIP;NodePort;LoadBalancer;ExternalName
+	Type corev1.ServiceType `json:"type"`
+
+	// +optional
+	// +kubebuilder:validation:Enum=Cluster;Local
+	InternalTrafficPolicy *corev1.ServiceInternalTrafficPolicy `json:"internalTrafficPolicy,omitempty"`
+
+	// +optional
+	// +kubebuilder:default:="Cluster"
+	// +kubebuilder:validation:Enum=Cluster;Local
+	ExternalTrafficPolicy corev1.ServiceExternalTrafficPolicy `json:"externalTrafficPolicy,omitempty"`
+}

--- a/internal/controller/typesensecluster_services.go
+++ b/internal/controller/typesensecluster_services.go
@@ -163,6 +163,15 @@ func (r *TypesenseClusterReconciler) createService(ctx context.Context, key clie
 		},
 	}
 
+	svcSpec := ts.Spec.Service
+	if svcSpec != nil {
+		svc.ObjectMeta.Labels = mergeLabels(svc.ObjectMeta.Labels, svcSpec.Labels)
+		svc.ObjectMeta.Annotations = mergeAnnotations(svc.ObjectMeta.Annotations, svcSpec.Annotations)
+		svc.Spec.Type = svcSpec.Type
+		svc.Spec.InternalTrafficPolicy = svcSpec.InternalTrafficPolicy
+		svc.Spec.ExternalTrafficPolicy = svcSpec.ExternalTrafficPolicy
+	}
+
 	err := ctrl.SetControllerReference(ts, svc, r.Scheme)
 	if err != nil {
 		return nil, err

--- a/internal/controller/typesensecluster_services.go
+++ b/internal/controller/typesensecluster_services.go
@@ -165,10 +165,7 @@ func (r *TypesenseClusterReconciler) createService(ctx context.Context, key clie
 
 	svcSpec := ts.Spec.Service
 	if svcSpec != nil {
-		svc.ObjectMeta.Labels = mergeLabels(svc.ObjectMeta.Labels, svcSpec.Labels)
-		svc.ObjectMeta.Annotations = mergeAnnotations(svc.ObjectMeta.Annotations, svcSpec.Annotations)
 		svc.Spec.Type = svcSpec.Type
-		svc.Spec.InternalTrafficPolicy = svcSpec.InternalTrafficPolicy
 		svc.Spec.ExternalTrafficPolicy = svcSpec.ExternalTrafficPolicy
 	}
 

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -65,6 +65,10 @@ func mergeLabels(maps ...map[string]string) map[string]string {
 	return merged
 }
 
+func mergeAnnotations(maps ...map[string]string) map[string]string {
+	return mergeLabels(maps...)
+}
+
 func getMergedLabels(def map[string]string, scoped map[string]string) map[string]string {
 	return mergeLabels(def, scoped)
 }

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -65,10 +65,6 @@ func mergeLabels(maps ...map[string]string) map[string]string {
 	return merged
 }
 
-func mergeAnnotations(maps ...map[string]string) map[string]string {
-	return mergeLabels(maps...)
-}
-
 func getMergedLabels(def map[string]string, scoped map[string]string) map[string]string {
 	return mergeLabels(def, scoped)
 }


### PR DESCRIPTION
Added in some basic configuration to the service spec for a typesense cluster.

I haven't worked with kubebuilder before so there may be an anti pattern or two in here.