### PR TITLE
feat: allow setting PersistentVolumeClaimRetentionPolicy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ test: manifests generate fmt vet setup-envtest ## Run tests.
 # The default setup assumes Kind is pre-installed and builds/loads the Manager Docker image locally.
 # CertManager is installed by default; skip with:
 # - CERT_MANAGER_INSTALL_SKIP=true
-KIND_CLUSTER ?= memcached-operator-test-e2e
+KIND_CLUSTER ?= typesense-operator-test-e2e
 
 .PHONY: setup-test-e2e
 setup-test-e2e: ## Set up a Kind cluster for e2e tests if it does not exist

--- a/api/v1alpha1/typesensecluster_types_storage.go
+++ b/api/v1alpha1/typesensecluster_types_storage.go
@@ -1,6 +1,9 @@
 package v1alpha1
 
-import "k8s.io/apimachinery/pkg/api/resource"
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
 
 type StorageSpec struct {
 
@@ -16,6 +19,8 @@ type StorageSpec struct {
 	AccessMode string `json:"accessMode,omitempty"`
 
 	Annotations map[string]string `json:"annotations,omitempty"`
+
+	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy"`
 }
 
 func (s *TypesenseClusterSpec) GetStorage() StorageSpec {

--- a/api/v1alpha1/typesensecluster_types_storage.go
+++ b/api/v1alpha1/typesensecluster_types_storage.go
@@ -18,8 +18,10 @@ type StorageSpec struct {
 	// +kubebuilder:default:=ReadWriteOnce
 	AccessMode string `json:"accessMode,omitempty"`
 
+	// +kubebuilder:validation:Optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
+	// +kubebuilder:validation:Optional
 	RetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"retentionPolicy"`
 }
 
@@ -32,5 +34,20 @@ func (s *TypesenseClusterSpec) GetStorage() StorageSpec {
 		Size:             resource.MustParse("100Mi"),
 		StorageClassName: "standard",
 		AccessMode:       "ReadWriteOnce",
+		RetentionPolicy: &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+			WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+			WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		},
+	}
+}
+
+func (s *TypesenseClusterSpec) GetStorageRetentionPolicy() *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy {
+	if s.Storage != nil && s.Storage.RetentionPolicy != nil {
+		return s.Storage.RetentionPolicy
+	}
+
+	return &appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy{
+		WhenDeleted: appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
+		WhenScaled:  appsv1.RetainPersistentVolumeClaimRetentionPolicyType,
 	}
 }

--- a/api/v1alpha1/typesensecluster_types_storage.go
+++ b/api/v1alpha1/typesensecluster_types_storage.go
@@ -20,7 +20,7 @@ type StorageSpec struct {
 
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	PersistentVolumeClaimRetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"persistentVolumeClaimRetentionPolicy"`
+	RetentionPolicy *appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy `json:"retentionPolicy"`
 }
 
 func (s *TypesenseClusterSpec) GetStorage() StorageSpec {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -240,6 +241,11 @@ func (in *StorageSpec) DeepCopyInto(out *StorageSpec) {
 		for key, val := range *in {
 			(*out)[key] = val
 		}
+	}
+	if in.PersistentVolumeClaimRetentionPolicy != nil {
+		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
+		**out = **in
 	}
 }
 

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -242,8 +242,8 @@ func (in *StorageSpec) DeepCopyInto(out *StorageSpec) {
 			(*out)[key] = val
 		}
 	}
-	if in.PersistentVolumeClaimRetentionPolicy != nil {
-		in, out := &in.PersistentVolumeClaimRetentionPolicy, &out.PersistentVolumeClaimRetentionPolicy
+	if in.RetentionPolicy != nil {
+		in, out := &in.RetentionPolicy, &out.RetentionPolicy
 		*out = new(appsv1.StatefulSetPersistentVolumeClaimRetentionPolicy)
 		**out = **in
 	}

--- a/charts/typesense-operator/templates/typesensecluster-crd.yaml
+++ b/charts/typesense-operator/templates/typesensecluster-crd.yaml
@@ -4271,6 +4271,27 @@ spec:
                     x-kubernetes-int-or-string: true
                   storageClassName:
                     type: string
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                 required:
                 - storageClassName
                 type: object

--- a/charts/typesense-operator/templates/typesensecluster-crd.yaml
+++ b/charts/typesense-operator/templates/typesensecluster-crd.yaml
@@ -4271,7 +4271,7 @@ spec:
                     x-kubernetes-int-or-string: true
                   storageClassName:
                     type: string
-                  persistentVolumeClaimRetentionPolicy:
+                  retentionPolicy:
                     description: |-
                       StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
                       created from the StatefulSet VolumeClaimTemplates.

--- a/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
+++ b/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
@@ -4326,6 +4326,27 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
+                  persistentVolumeClaimRetentionPolicy:
+                    description: |-
+                      StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
+                      created from the StatefulSet VolumeClaimTemplates.
+                    properties:
+                      whenDeleted:
+                        description: |-
+                          WhenDeleted specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is deleted. The default policy
+                          of `Retain` causes PVCs to not be affected by StatefulSet deletion. The
+                          `Delete` policy causes those PVCs to be deleted.
+                        type: string
+                      whenScaled:
+                        description: |-
+                          WhenScaled specifies what happens to PVCs created from StatefulSet
+                          VolumeClaimTemplates when the StatefulSet is scaled down. The default
+                          policy of `Retain` causes PVCs to not be affected by a scaledown. The
+                          `Delete` policy causes the associated PVCs for any excess pods above
+                          the replica count to be deleted.
+                        type: string
+                    type: object
                   size:
                     anyOf:
                     - type: integer
@@ -4336,6 +4357,7 @@ spec:
                   storageClassName:
                     type: string
                 required:
+                - persistentVolumeClaimRetentionPolicy
                 - storageClassName
                 type: object
               tolerations:

--- a/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
+++ b/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
@@ -4357,7 +4357,6 @@ spec:
                   storageClassName:
                     type: string
                 required:
-                - retentionPolicy
                 - storageClassName
                 type: object
               tolerations:

--- a/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
+++ b/config/crd/bases/ts.opentelekomcloud.com_typesenseclusters.yaml
@@ -4326,7 +4326,7 @@ spec:
                     additionalProperties:
                       type: string
                     type: object
-                  persistentVolumeClaimRetentionPolicy:
+                  retentionPolicy:
                     description: |-
                       StatefulSetPersistentVolumeClaimRetentionPolicy describes the policy used for PVCs
                       created from the StatefulSet VolumeClaimTemplates.
@@ -4357,7 +4357,7 @@ spec:
                   storageClassName:
                     type: string
                 required:
-                - persistentVolumeClaimRetentionPolicy
+                - retentionPolicy
                 - storageClassName
                 type: object
               tolerations:

--- a/config/samples/ts_v1alpha1_typesensecluster.yaml
+++ b/config/samples/ts_v1alpha1_typesensecluster.yaml
@@ -11,3 +11,6 @@ spec:
   storage:
     size: 100Mi
     storageClassName: standard
+    persistentVolumeClaimRetentionPolicy: 
+      whenDeleted: Delete
+      whenScaled: Retain

--- a/config/samples/ts_v1alpha1_typesensecluster.yaml
+++ b/config/samples/ts_v1alpha1_typesensecluster.yaml
@@ -11,6 +11,6 @@ spec:
   storage:
     size: 100Mi
     storageClassName: standard
-    persistentVolumeClaimRetentionPolicy: 
+    retentionPolicy: 
       whenDeleted: Delete
       whenScaled: Retain

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -486,6 +486,7 @@ func (r *TypesenseClusterReconciler) buildStatefulSet(ctx context.Context, key c
 					},
 				},
 			},
+			PersistentVolumeClaimRetentionPolicy: ts.Spec.Storage.PersistentVolumeClaimRetentionPolicy,
 		},
 	}
 

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -486,7 +486,7 @@ func (r *TypesenseClusterReconciler) buildStatefulSet(ctx context.Context, key c
 					},
 				},
 			},
-			PersistentVolumeClaimRetentionPolicy: ts.Spec.Storage.RetentionPolicy,
+			PersistentVolumeClaimRetentionPolicy: ts.Spec.GetStorageRetentionPolicy(),
 		},
 	}
 

--- a/internal/controller/typesensecluster_statefulset.go
+++ b/internal/controller/typesensecluster_statefulset.go
@@ -486,7 +486,7 @@ func (r *TypesenseClusterReconciler) buildStatefulSet(ctx context.Context, key c
 					},
 				},
 			},
-			PersistentVolumeClaimRetentionPolicy: ts.Spec.Storage.PersistentVolumeClaimRetentionPolicy,
+			PersistentVolumeClaimRetentionPolicy: ts.Spec.Storage.RetentionPolicy,
 		},
 	}
 

--- a/internal/controller/typesensecluster_statefulset_hash.go
+++ b/internal/controller/typesensecluster_statefulset_hash.go
@@ -43,7 +43,7 @@ func (r *TypesenseClusterReconciler) shouldUpdateStatefulSet(sts *appsv1.Statefu
 
 	// SpecReplicasChanged
 	if *sts.Spec.Replicas != ts.Spec.Replicas &&
-		(condition.Reason != string(ConditionReasonQuorumDowngraded) || condition.Reason != string(ConditionReasonQuorumQueuedWrites)) {
+		(condition.Reason != string(ConditionReasonQuorumDowngraded) && condition.Reason != string(ConditionReasonQuorumQueuedWrites)) {
 		triggers = append(triggers, SpecReplicasChanged)
 		update = false
 		scaleOnly = true

--- a/internal/controller/typesensecluster_statefulset_hash.go
+++ b/internal/controller/typesensecluster_statefulset_hash.go
@@ -17,15 +17,16 @@ import (
 type UpdateStatefulSetTrigger string
 
 var (
-	SpecReplicasChanged             UpdateStatefulSetTrigger = "SpecReplicasChanged"
-	HashAnnotationChanged           UpdateStatefulSetTrigger = "HashAnnotationChanged"
-	PodAnnotationsChanged           UpdateStatefulSetTrigger = "PodAnnotationsChanged"
-	StatefulSetAnnotationsChanged   UpdateStatefulSetTrigger = "StatefulSetAnnotationsChanged"
-	SpecResourcesChanged            UpdateStatefulSetTrigger = "SpecResourcesChanged"
-	PodSecurityContextChanged       UpdateStatefulSetTrigger = "PodSecurityContextChanged"
-	InvalidContainerCount           UpdateStatefulSetTrigger = "InvalidContainerCount"
-	ContainerSecurityContextChanged UpdateStatefulSetTrigger = "ContainerSecurityContextChanged"
-	SpecTypesenseVersionChanged     UpdateStatefulSetTrigger = "SpecTypesenseVersionChanged"
+	SpecReplicasChanged                UpdateStatefulSetTrigger = "SpecReplicasChanged"
+	HashAnnotationChanged              UpdateStatefulSetTrigger = "HashAnnotationChanged"
+	PodAnnotationsChanged              UpdateStatefulSetTrigger = "PodAnnotationsChanged"
+	StatefulSetAnnotationsChanged      UpdateStatefulSetTrigger = "StatefulSetAnnotationsChanged"
+	StatefulSetARetentionPolicyChanged UpdateStatefulSetTrigger = "StatefulSetARetentionPolicyChanged"
+	SpecResourcesChanged               UpdateStatefulSetTrigger = "SpecResourcesChanged"
+	PodSecurityContextChanged          UpdateStatefulSetTrigger = "PodSecurityContextChanged"
+	InvalidContainerCount              UpdateStatefulSetTrigger = "InvalidContainerCount"
+	ContainerSecurityContextChanged    UpdateStatefulSetTrigger = "ContainerSecurityContextChanged"
+	SpecTypesenseVersionChanged        UpdateStatefulSetTrigger = "SpecTypesenseVersionChanged"
 )
 
 func (r *TypesenseClusterReconciler) shouldUpdateStatefulSet(sts *appsv1.StatefulSet, desired *appsv1.StatefulSet, ts *tsv1alpha1.TypesenseCluster) (update bool, scaleOnly bool, triggers []UpdateStatefulSetTrigger) {
@@ -68,6 +69,12 @@ func (r *TypesenseClusterReconciler) shouldUpdateStatefulSet(sts *appsv1.Statefu
 	// StatefulSetAnnotationsChanged
 	if !apiequality.Semantic.DeepEqual(stsAnnotations, desired.ObjectMeta.Annotations) {
 		triggers = append(triggers, StatefulSetAnnotationsChanged)
+		update = true
+	}
+
+	// StatefulSetARetentionPolicyChanged
+	if !apiequality.Semantic.DeepEqual(sts.Spec.PersistentVolumeClaimRetentionPolicy, desired.Spec.PersistentVolumeClaimRetentionPolicy) {
+		triggers = append(triggers, StatefulSetARetentionPolicyChanged)
 		update = true
 	}
 


### PR DESCRIPTION
Adds support for configuring StatefulSet PVC retention via `spec.storage.persistentVolumeClaimRetentionPolicy` on `TypesenseCluster`.

This lets you control what happens to PVCs on scale-down or cluster deletion (Retain/Delete) by wiring the CRD field through to the generated StatefulSet. I've added to the base sample what that looks like.

The main use case for me is short-lived test clusters, where PVCs should be cleaned up automatically when clusters are torn down, while still leaving production-like defaults.

I also noticed the local kind cluster was named incorrectly and there was a suspect OR condition flagged by `go vet` which always evaluated to true. I believe it was mean to be "when `condition.Reason` is neither `ConditionReasonQuorumDowngraded` or `ConditionReasonQuorumQueuedWrites`" which is what i've amended it to.

Also mostly FYI but running `make helm` overwrote a ton of stuff, almost all of which were out of scope of this PR. I've cherry-picked the bits of that this PR cares about.