### PR TITLE
fix(quorum): correct ConfigMap key and bootstrap wait gate

### DIFF
--- a/internal/controller/typesensecluster_quorum.go
+++ b/internal/controller/typesensecluster_quorum.go
@@ -116,8 +116,12 @@ func (r *TypesenseClusterReconciler) ReconcileQuorum(ctx context.Context, ts *ts
 	r.logger.V(debugLevel).Info("reporting cluster status", "status", clusterStatus)
 
 	if clusterStatus == ClusterStatusSplitBrain {
-		nodeslist := strings.Split(quorum.NodesListConfigMap.Data["nodeslist"], ",")
-		if _, c := contains(nodeslist, fmt.Sprintf(ClusterStatefulSet, ts.Name)); c == true {
+		rawNodeslist, ok := quorum.NodesListConfigMap.Data["nodes"]
+		if !ok || rawNodeslist == "" {
+			return ConditionReasonQuorumNotReady, 0, fmt.Errorf("configmap %s is missing 'nodes' key", quorum.NodesListConfigMap.Name)
+		}
+		nodeslist := strings.Split(rawNodeslist, ",")
+		if hasHostnameBasedNodes(nodeslist, fmt.Sprintf(ClusterStatefulSet, ts.Name)) {
 			return ConditionReasonQuorumNotReadyWaitATerm, 0, nil
 		}
 		return r.downgradeQuorum(ctx, ts, quorum.NodesListConfigMap, stsObjectKey, sts.Status.ReadyReplicas, int32(quorum.MinRequiredNodes))
@@ -170,8 +174,12 @@ func (r *TypesenseClusterReconciler) ReconcileQuorum(ctx context.Context, ts *ts
 	}
 
 	if clusterStatus == ClusterStatusElectionDeadlock {
-		nodeslist := strings.Split(quorum.NodesListConfigMap.Data["nodeslist"], ",")
-		if _, c := contains(nodeslist, fmt.Sprintf(ClusterStatefulSet, ts.Name)); c == true {
+		rawNodeslist, ok := quorum.NodesListConfigMap.Data["nodes"]
+		if !ok || rawNodeslist == "" {
+			return ConditionReasonQuorumNotReady, 0, fmt.Errorf("configmap %s is missing 'nodes' key", quorum.NodesListConfigMap.Name)
+		}
+		nodeslist := strings.Split(rawNodeslist, ",")
+		if hasHostnameBasedNodes(nodeslist, fmt.Sprintf(ClusterStatefulSet, ts.Name)) {
 			return ConditionReasonQuorumNotReadyWaitATerm, 0, nil
 		}
 		return r.downgradeQuorum(ctx, ts, quorum.NodesListConfigMap, stsObjectKey, int32(healthyNodes), int32(minRequiredNodes))
@@ -380,4 +388,14 @@ func (r *TypesenseClusterReconciler) updatePodReadinessGate(ctx context.Context,
 
 	//r.logger.V(debugLevel).Info("updating pod readiness gate condition", "pod", pod.Name, "condition", condition.Type, "conditionStatus", condition.Status)
 	return nil
+}
+
+func hasHostnameBasedNodes(nodes []string, statefulSetName string) bool {
+	for _, node := range nodes {
+		if strings.Contains(node, statefulSetName) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/controller/typesensecluster_quorum_helpers.go
+++ b/internal/controller/typesensecluster_quorum_helpers.go
@@ -159,7 +159,11 @@ func (r *TypesenseClusterReconciler) getQuorum(ctx context.Context, ts *tsv1alph
 		return &Quorum{}, err
 	}
 
-	nodes := strings.Split(cm.Data["nodes"], ",")
+	rawNodes, ok := cm.Data["nodes"]
+	if !ok || strings.TrimSpace(rawNodes) == "" {
+		return &Quorum{}, fmt.Errorf("configmap %s is missing 'nodes' key", cm.Name)
+	}
+	nodes := strings.Split(rawNodes, ",")
 	availableNodes := len(nodes)
 	minRequiredNodes := getMinimumRequiredNodes(int(sts.Status.Replicas))
 


### PR DESCRIPTION
Closes #254

## Summary

- The quorum reconciler was reading from a non-existent `\"nodeslist\"` key. The actual data keys written by the operator are `\"nodes\"` and `\"fallback\"`. In Go, a missing map key silently returns `\"\"`, so `strings.Split(\"\", \",\")` produced `[\"\"]`.
- This made `QuorumNotReadyWaitATerm` unreachable in both the `ClusterStatusSplitBrain` and `ClusterStatusElectionDeadlock` branches, causing `downgradeQuorum` to be called prematurely during recovery.
- There was a second independent bug: the wait gate used `contains()` (exact equality), which would not match hostname-based entries like `typesense-v3-sts-0.typesense-v3-sts-svc:8107:8108` even if the key had been correct.

## Changes

- **`typesensecluster_quorum.go`**
  - Read from correct `\"nodes\"` key in both recovery branches
  - Add key existence + empty-value guard with clear error if missing
  - Replace exact-match `contains()` gate with `hasHostnameBasedNodes()` substring check so bootstrap hostname entries are detected correctly
- **`typesensecluster_quorum_helpers.go`**
  - Add same key existence + empty-value guard in `getQuorum()` where `cm.Data[\"nodes\"]` was previously unguarded

## Test Plan

- [x] Deployed patched image to a local kind cluster
- [x] Applied sample `TypesenseCluster` and observed ConfigMap `nodes` transition from StatefulSet DNS hostnames to pod IPs during bootstrapping
- [x] Confirmed wait gate is reachable during bootstrap
- [x] Confirmed `QuorumReady` after cluster stabilization
- [x] Confirmed downgrade + recovery behavior via controlled disruption tests
- [x] No `\"missing 'nodes' key\"` errors in normal operation

### Example observed log (after fix)

```text
reason: "QuorumNotReadyWaitATerm"
```

## Impact on Existing Deployments

Any cluster running upstream behavior could silently bypass the intended wait gate during split-brain or election-deadlock recovery, increasing the risk of premature quorum downgrade.